### PR TITLE
Commented out delivery date 

### DIFF
--- a/partials/checkout-shipping-method.htm
+++ b/partials/checkout-shipping-method.htm
@@ -18,10 +18,12 @@
                 <thead>                
                     <th>Shipping Method</th>
                     <th>Quote</th>
+                    {# Enable Delivery Date for methods other than UPS
                     {% if option.deliveryDate  %}
                     	<th>Date</th>
                     {% endif %}
-                    <th>&nbsp;</th>
+                    <th>&nbsp;</th> 
+                    #}
                 </thead>
                 <tbody>
 
@@ -42,11 +44,13 @@
                                     {{ not option.is_free ? option.quote|currency : 'free' }}
                                 {% endif %}
                             </td>
+                            {# Enable Delivery Date for methods other than UPS
                             {% if option.deliveryDate  %}
 	                            <td>
 	                            	{{ option.deliveryDate }}
 	                            </td>
-                            {% endif %}
+                            {% endif %} 
+                            #}
                             <td class="text-right">
                                 <div class="custom-control custom-radio custom-control-inline">
                                     <input id="shipping-method-{{ index }}" 


### PR DESCRIPTION
Issue #5 delivery date options throwing error for some shipping methods. 

I left it commented out as it does work for most, so the options to use it is there. 