### PR TITLE
Removed extra text from theme manifest author

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prod": "npm run production",
     "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
-  "author": "LemonStand <support@lemonstand.com> (http://docs.lemonstand.com)",
+  "author": "LemonStand",
   "license": "MPL-2.0",
   "dependencies": {
     "block-ui": "^2.70.1",


### PR DESCRIPTION
Removed `<support@lemonstand.com> (http://docs.lemonstand.com)` from description. 

Fixes issue: 
https://github.com/lemonstand/lemonstand-2/issues/5766