### PR TITLE
Fixes reverted minicart-content reference

### DIFF
--- a/partials/shop-cart-content.htm
+++ b/partials/shop-cart-content.htm
@@ -52,7 +52,7 @@
                             <a class="btn btn-outline-primary mr-md-auto" href="{{ site_url('/shop') }}">Continue Shopping</a>
                             <a class="btn btn-outline-dark" href="#"
                                 data-ajax-handler="shop:cart"
-                                data-ajax-update=".minicart=shop-minicart, .minicart-content=shop-minicart-content, .minicart-counter=shop-minicart-counter, #cart-content=shop-cart-content">
+                                data-ajax-update=".minicart=shop-minicart, .minicart-content=shop-minicart, .minicart-counter=shop-minicart-counter, #cart-content=shop-cart-content">
                                 Update Cart
                             </a>
                             <a class="btn btn-primary" href="{{ site_url('/checkout') }}">Checkout</a>


### PR DESCRIPTION
Fixes an accidentally reverted reference to a missing partial `minicart-content` (fixed in a previous PR).